### PR TITLE
Fix username link encoding for special characters. Fixes #30

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -98,13 +98,13 @@
                 {{if .Resolution}}{{.Resolution}}{{else}}{{.ConfirmationStatus}}{{end}}
               </div>
             </div></td>
-            <td><a class="issue-table-user" href="/user/{{.ReporterName}}">
+            <td><a class="issue-table-user" href="/user/{{urlPathEscape .ReporterName}}">
               {{if .ReporterAvatar}}
                 <img class="avatar" src="{{.ReporterAvatar}}" alt="" width="24" height="24">
               {{end}}
               {{.ReporterName}}
             </a></td>
-            <td><a class="issue-table-user" href="/user/{{.AssigneeName}}">
+            <td><a class="issue-table-user" href="/user/{{urlPathEscape .AssigneeName}}">
               {{if .AssigneeAvatar}}
                 <img class="avatar" src="{{.AssigneeAvatar}}" alt="" width="24" height="24">
               {{end}}

--- a/templates/pages/issue.html
+++ b/templates/pages/issue.html
@@ -140,7 +140,7 @@
           {{if .Issue.CreatorAvatar}}
             <img class="avatar" src="{{.Issue.CreatorAvatar}}" alt="" width="24" height="24">
           {{end}}
-          <a class="user-link" href="/user/{{.Issue.CreatorName}}">
+          <a class="user-link" href="/user/{{urlPathEscape .Issue.CreatorName}}">
             {{.Issue.CreatorName}}
           </a>
         </p>
@@ -149,7 +149,7 @@
         {{if .Issue.ReporterAvatar}}
           <img class="avatar" src="{{.Issue.ReporterAvatar}}" alt="" width="24" height="24">
         {{end}}
-        <a class="user-link" href="/user/{{.Issue.ReporterName}}">
+        <a class="user-link" href="/user/{{urlPathEscape .Issue.ReporterName}}">
           {{.Issue.ReporterName}}
         </a>
       </p>
@@ -158,7 +158,7 @@
           {{if .Issue.AssigneeAvatar}}
             <img class="avatar" src="{{.Issue.AssigneeAvatar}}" alt="" width="24" height="24">
           {{end}}
-          <a class="user-link" href="/user/{{.Issue.AssigneeName}}">
+          <a class="user-link" href="/user/{{urlPathEscape .Issue.AssigneeName}}">
             {{.Issue.AssigneeName}}
           </a>
         {{else}}
@@ -233,7 +233,7 @@
       {{if .AuthorAvatar}}
         <img class="avatar" src="{{.AuthorAvatar}}" alt="" width="24" height="24">
       {{end}}
-      <a class="user-link" href="/user/{{.AuthorName}}"><span class="comment-author">{{.AuthorName}}</span></a>
+      <a class="user-link" href="/user/{{urlPathEscape .AuthorName}}"><span class="comment-author">{{.AuthorName}}</span></a>
       <a class="comment-time" href="#{{.Anchor}}">
         <time datetime="{{formatTime .Date}}">{{formatTime .Date}}</time>
       </a>

--- a/templates/pages/user.html
+++ b/templates/pages/user.html
@@ -83,7 +83,7 @@
       {{if .AuthorAvatar}}
         <img class="avatar" src="{{.AuthorAvatar}}" alt="" width="24" height="24">
       {{end}}
-      <a class="user-link" href="/user/{{.AuthorName}}"><span class="comment-author">{{.AuthorName}}</span></a>
+      <a class="user-link" href="/user/{{urlPathEscape .AuthorName}}"><span class="comment-author">{{.AuthorName}}</span></a>
       <span class="comment-on">on</span>
       <a class="comment-link" href="/{{.Issue.Key}}#{{.Anchor}}">
         <span class="issue-key">{{.Issue.Key}}</span>

--- a/views.go
+++ b/views.go
@@ -43,6 +43,7 @@ func render(w http.ResponseWriter, name string, data any) {
 		"add": func(a int, b int) int {
 			return a + b
 		},
+		"urlPathEscape": url.PathEscape,
 	}).ParseFiles("templates/base.html", fmt.Sprintf("templates/%s", name))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Usernames with special characters like brackets would lead to incorrect links because those characters weren't properly encoded. 

This PR adds a `urlPathEscape` [function](https://pkg.go.dev/net/url#PathEscape) to address this, fixing #30. All user links should now properly encode all characters before placing them in a URL.