### PR TITLE
Resizable issue table columns

### DIFF
--- a/model/issue.go
+++ b/model/issue.go
@@ -102,17 +102,27 @@ func (i *Issue) HasEnvironment() bool {
 	return i.Environment != "" && !IsEmptyADF(i.Environment)
 }
 
-func (i *Issue) ShortAffectedVersions() string {
-	if i.AffectedVersions == nil {
-		return ""
-	}
+type VisibleVersions struct {
+	Top    []string
+	Middle []string
+	Bottom []string
+	Count  int
+}
+
+func (i *Issue) VisibleAffectedVersions() VisibleVersions {
 	n := len(i.AffectedVersions)
 	if n <= 10 {
-		return strings.Join(i.AffectedVersions, ", ")
+		return VisibleVersions{
+			Top:   i.AffectedVersions,
+			Count: n,
+		}
 	}
-	short := append(i.AffectedVersions[:5], "...")
-	short = append(short, i.AffectedVersions[n-5:]...)
-	return strings.Join(short, ", ")
+	return VisibleVersions{
+		Top:    i.AffectedVersions[:5],
+		Middle: i.AffectedVersions[5 : n-5],
+		Bottom: i.AffectedVersions[n-5:],
+		Count:  n,
+	}
 }
 
 func (i *Issue) TotalVotes() int {

--- a/static/style.css
+++ b/static/style.css
@@ -1086,3 +1086,17 @@ tbody .issue-table-key {
   width: 64px;
   height: 64px;
 }
+
+.expand-inline-button {
+  padding: 0 0.5rem;
+  border: 1px solid var(--gray-300);
+  background-color: transparent;
+  color: var(--gray-600);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.expand-inline-button:hover {
+  background-color: var(--gray-100);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -33,6 +33,15 @@ body {
   color: var(--gray-950);
 }
 
+body.resizing {
+  cursor: col-resize !important;
+}
+
+body.resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
+}
+
 .content {
   padding-top: 56px;
   min-height: 100vh;
@@ -306,6 +315,25 @@ footer a:hover {
   height: 2rem;
 }
 
+.issue-table th {
+  position: relative;
+}
+
+.resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 5px;
+  cursor: col-resize;
+  user-select: none;
+  height: 100%;
+  z-index: 10;
+}
+
+.resizer:hover {
+  border-right: 2px solid var(--link);
+}
+
 .issue-table td > *, .issue-table th > * {
   padding: 0.25rem 0.5rem;
   height: 2rem;
@@ -363,7 +391,7 @@ tbody .issue-table-key {
 }
 
 .issue-table-summary {
-  width: 600px;
+  width: var(--col-summary-width, 600px);
 }
 
 .issue-table-status {
@@ -374,6 +402,9 @@ tbody .issue-table-key {
   width: 150px;
   text-decoration: none;
 }
+
+.col-reporter { width: var(--col-reporter-width, 150px); }
+.col-assignee { width: var(--col-assignee-width, 150px); }
 
 .issue-table-user:hover, .issue-table-user:focus {
   text-decoration: underline;

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -79,14 +79,14 @@
     {{end}}
   </div>
   <div class="issue-table-container">
-    <table class="issue-table">
+    <table class="issue-table" id="resizable-table">
       <thead>
         <tr>
           <th><div class="issue-table-key">Key</div></th>
-          <th><div class="issue-table-summary">Summary</div></th>
+          <th data-col="summary"><div class="issue-table-summary">Summary</div><div class="resizer"></div></th>
           <th><div class="issue-table-status">Status</div></th>
-          <th><div class="issue-table-user">Reporter</div></th>
-          <th><div class="issue-table-user">Assignee</div></th>
+          <th data-col="reporter"><div class="issue-table-user col-reporter">Reporter</div><div class="resizer"></div></th>
+          <th data-col="assignee"><div class="issue-table-user col-assignee">Assignee</div><div class="resizer"></div></th>
           <th><div class="issue-table-time">Created</div></th>
         </tr>
       </thead>
@@ -100,25 +100,67 @@
                 {{if .Resolution}}{{.Resolution}}{{else}}{{.ConfirmationStatus}}{{end}}
               </div>
             </div></td>
-            <td><a class="issue-table-user" href="/user/{{urlPathEscape .ReporterName}}">
+            <td><a class="issue-table-user col-reporter" href="/user/{{urlPathEscape .ReporterName}}">
               {{if .ReporterAvatar}}
                 <img class="avatar" src="{{.ReporterAvatar}}" alt="" width="24" height="24">
               {{end}}
               {{.ReporterName}}
             </a></td>
-            <td><a class="issue-table-user" {{if .AssigneeName}}href="/user/{{urlPathEscape .AssigneeName}}"{{end}}>
+            <td><a class="issue-table-user col-assignee" {{if .AssigneeName}}href="/user/{{urlPathEscape .AssigneeName}}"{{end}}>
               {{if .AssigneeAvatar}}
                 <img class="avatar" src="{{.AssigneeAvatar}}" alt="" width="24" height="24">
               {{end}}
               {{.AssigneeName}}
             </a></td>
-            <td><time datetime="{{formatTime .CreatedDate}}">{{formatTime .CreatedDate}}</time></td>
+            <td><div class="issue-table-time"><time datetime="{{formatTime .CreatedDate}}">{{formatTime .CreatedDate}}</time></div></td>
           </tr>
         {{end}}
       </tbody>
     </table>
   </div>
 </div>
+
+<script>
+  (() => {
+    let th, startX, startWidth, initialWidth, colName, table;
+
+    const onMouseMove = (e) => {
+      if (!th) return;
+      const currentMove = startWidth + (e.pageX - startX);
+      const newWidth = Math.max(initialWidth, Math.min(initialWidth * 2, currentMove));
+      table.style.setProperty(`--col-${colName}-width`, `${newWidth}px`);
+    };
+
+    const onMouseUp = () => {
+      document.body.classList.remove('resizing');
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      th = null;
+    };
+
+    document.addEventListener('mousedown', (e) => {
+      if (!e.target.classList.contains('resizer')) return;
+      
+      th = e.target.parentElement;
+      table = document.getElementById('resizable-table');
+      colName = th.dataset.col;
+      startX = e.pageX;
+
+      const targetDiv = th.querySelector('div:first-child');
+      startWidth = targetDiv.offsetWidth;
+      
+      if (!th.dataset.initialWidth) {
+          th.dataset.initialWidth = startWidth;
+      }
+      initialWidth = parseInt(th.dataset.initialWidth);
+
+      document.body.classList.add('resizing');
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+      e.preventDefault();
+    });
+  })();
+</script>
 {{end}}
 
 {{template "base" .}}

--- a/templates/pages/issue.html
+++ b/templates/pages/issue.html
@@ -189,7 +189,11 @@
       {{end}}
       <p><label>Labels:</label> {{join .Issue.Labels}}</p>
       {{if .Issue.IsProject "MC" "MCPE"}}
-      <p><label>Affects Versions:</label> {{.Issue.ShortAffectedVersions}}</p>
+      <p><label>Affects Versions:</label>
+        {{with .Issue.VisibleAffectedVersions}}
+        {{join .Top}}{{if .Middle}}, <button class="expand-inline-button" data-expand="hidden-versions-{{$.Issue.Key}}">{{len .Middle}} more</button><span style="display:none;" id="hidden-versions-{{$.Issue.Key}}">{{join .Middle}}</span>{{end}}{{if .Bottom}}, {{join .Bottom}}{{end}}
+        {{end}}
+      </p>
       <p><label>Fix Versions:</label> {{join .Issue.FixVersions}}</p>
       {{end}}
       <p class="sync-note" id="sync-note" {{if and (not .Issue.IsUpToDate) (not .IsRefresh)}}hx-get="/api/issues/{{.Issue.Key}}/refresh" hx-trigger="load delay:1s" hx-swap="none"{{end}}>


### PR DESCRIPTION
Makes the **Summary**, **Reporter** and **Assignee** columns of the issue table resizable and closes #37. It wouldn't make sense to make the other columns resizable, since only these three contain strings from users. I limited the resizing so that it could not exceed twice the original size or be smaller than it.